### PR TITLE
fix: properly pass permset names to core

### DIFF
--- a/src/commands/force/user/permset/assign.ts
+++ b/src/commands/force/user/permset/assign.ts
@@ -66,7 +66,7 @@ export class UserPermsetAssignCommand extends SfdxCommand {
         const fields: UserFields = await user.retrieve(username);
 
         try {
-          await user.assignPermissionSets(fields.id, this.flags.permsetname);
+          await user.assignPermissionSets(fields.id, [this.flags.permsetname]);
           this.successes.push({
             name: aliasOrUsername,
             value: this.flags.permsetname,


### PR DESCRIPTION
### What does this PR do?
fixes the type `sfdx-core` is expecting when assigning permsets

### What issues does this PR fix or reference?
