### PR TITLE
fix: object for one user, array for multiple [skip-validate-pr]

### DIFF
--- a/src/commands/force/user/password/generate.ts
+++ b/src/commands/force/user/password/generate.ts
@@ -32,7 +32,7 @@ export class UserPasswordGenerateCommand extends SfdxCommand {
   private usernames: string[];
   private passwordData: PasswordData[] = [];
 
-  public async run(): Promise<PasswordData[]> {
+  public async run(): Promise<PasswordData[] | PasswordData> {
     this.usernames = (this.flags.onbehalfof as string[]) ?? [this.org.getUsername()];
 
     for (const aliasOrUsername of this.usernames) {
@@ -87,7 +87,7 @@ export class UserPasswordGenerateCommand extends SfdxCommand {
 
     this.print();
 
-    return this.passwordData;
+    return this.passwordData.length === 1 ? this.passwordData[0] : this.passwordData;
   }
 
   private print(): void {

--- a/test/commands/user/password/generate.test.ts
+++ b/test/commands/user/password/generate.test.ts
@@ -78,7 +78,7 @@ describe('force:user:password:generate', () => {
     .stdout()
     .command(['force:user:password:generate', '--json'])
     .it('should generate a new password for the default user', (ctx) => {
-      const expected = [{ username: 'defaultusername@test.com', password: 'abc' }];
+      const expected = { username: 'defaultusername@test.com', password: 'abc' };
       const result = JSON.parse(ctx.stdout).result;
       expect(result).to.deep.equal(expected);
       expect(authInfoStub.update.callCount).to.equal(1);


### PR DESCRIPTION
### What does this PR do?
fixes json backwards compatibility. One password generated should return an object, multiple should return an array of the objects
### What issues does this PR fix or reference?
