### PR TITLE
fix: prevent undefined via optional chaining

### DIFF
--- a/src/commands/force/user/list.ts
+++ b/src/commands/force/user/list.ts
@@ -47,7 +47,7 @@ export class UserListCommand extends SfdxCommand {
       // if they passed in a alias and it maps to something we have an Alias.
       const alias = aliases.getKeysByValue(authData.getUsername())[0];
       const configAgg = ConfigAggregator.getInstance();
-      const defaultUserOrAlias = configAgg.getLocalConfig().get('defaultusername');
+      const defaultUserOrAlias = configAgg.getLocalConfig()?.get('defaultusername');
       return {
         defaultMarker: defaultUserOrAlias === username || defaultUserOrAlias === alias ? '(A)' : '',
         alias: alias || '',

--- a/test/commands/user/list.test.ts
+++ b/test/commands/user/list.test.ts
@@ -123,6 +123,40 @@ describe('force:user:list', () => {
 
   test
     .do(async () => {
+      await prepareStubs();
+      const cfa = ConfigAggregator.getInstance();
+      stubMethod($$.SANDBOX, cfa, 'getLocalConfig').returns(undefined);
+    })
+    .stdout()
+    .command([
+      'force:user:list',
+      '--json',
+      '--targetusername',
+      'testUser1@test.com',
+      '--targetdevhubusername',
+      'devhub@test.com',
+    ])
+    .it('handles scenario with no localConfig available', (ctx) => {
+      // testUser1@test.com is aliased to testUser
+      const expected = [
+        {
+          defaultMarker: '',
+          alias: 'testAlias',
+          username: 'testuser@test.com',
+          profileName: 'Analytics Cloud Integration User',
+          orgId: 'abc123',
+          accessToken: 'accessToken',
+          instanceUrl: 'instanceURL',
+          loginUrl: 'login.test.com',
+          userId: '0052D0000043PbGQAU',
+        },
+      ];
+      const result = JSON.parse(ctx.stdout).result;
+      expect(result).to.deep.equal(expected);
+    });
+
+  test
+    .do(async () => {
       await prepareStubs(true);
     })
     .stdout()


### PR DESCRIPTION
### What does this PR do?
prevents ugly error calling a method on a potentially undefined object
defaultMarker now does what the help says (not  related to default org, but the main user on the org)
prevent list out-of-bounds error on users with no alias
parallelize queries for perf
unit testing with a secondary user on the org (to cover no-alias and not-default scenarios)

### What issues does this PR fix or reference?
@W-8877040@

error repro:
run force:user:list -u whatever on some org with auth files from a folder where there is no local or global defaultusername