### PR TITLE
Sm/fix permset assign user not found

### DIFF
--- a/src/commands/force/user/permset/assign.ts
+++ b/src/commands/force/user/permset/assign.ts
@@ -8,7 +8,6 @@
 import * as os from 'os';
 import { flags, FlagsConfig, SfdxCommand } from '@salesforce/command';
 import { Aliases, Connection, Messages, Org, SfdxError, User } from '@salesforce/core';
-import { QueryResult } from 'jsforce';
 
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/plugin-user', 'permset.assign');
@@ -43,29 +42,27 @@ export class UserPermsetAssignCommand extends SfdxCommand {
       description: messages.getMessage('flags.onBehalfOf'),
     }),
   };
-  private usernames: string[];
   private readonly successes: SuccessMsg[] = [];
   private readonly failures: FailureMsg[] = [];
 
   public async run(): Promise<Result> {
     try {
-      this.usernames = (this.flags.onbehalfof as string[]) ?? [this.org.getUsername()];
+      const aliasOrUsernames = (this.flags.onbehalfof as string[]) ?? [this.org.getUsername()];
 
       const connection: Connection = this.org.getConnection();
       const org = await Org.create({ connection });
 
-      for (const username of this.usernames) {
-        // Convert any aliases to usernames
-        const aliasOrUsername = (await Aliases.fetch(username)) || username;
+      for (const aliasOrUsername of aliasOrUsernames) {
+        // Attempt to convert any aliases to usernames.  Not found alias will be **assumed** to be a username
+        const username = (await Aliases.fetch(aliasOrUsername)) || aliasOrUsername;
         const user: User = await User.create({ org });
         // get userId of whomever the permset will be assigned to via query to avoid AuthInfo if remote user
-        const queryResult: QueryResult<{ Id: string }> = await connection.query(
+        const queryResult = await connection.singleRecordQuery<{ Id: string }>(
           `SELECT Id FROM User WHERE Username='${username}'`
         );
-        const userId = queryResult.records[0].Id;
 
         try {
-          await user.assignPermissionSets(userId, [this.flags.permsetname]);
+          await user.assignPermissionSets(queryResult.Id, [this.flags.permsetname]);
           this.successes.push({
             name: aliasOrUsername,
             value: this.flags.permsetname as string,

--- a/test/commands/user/permset/assign.test.ts
+++ b/test/commands/user/permset/assign.test.ts
@@ -24,7 +24,7 @@ describe('force:user:permset:assign', () => {
       stubMethod($$.SANDBOX, User.prototype, 'assignPermissionSets').resolves();
     }
 
-    stubMethod($$.SANDBOX, Aliases, 'fetch').withArgs('testUser1@test.com').resolves('testAlias');
+    stubMethod($$.SANDBOX, Aliases, 'fetch').withArgs('testAlias').resolves('testUser1@test.com');
   }
 
   test
@@ -36,7 +36,7 @@ describe('force:user:permset:assign', () => {
       'force:user:permset:assign',
       '--json',
       '--onbehalfof',
-      'testUser1@test.com, testUser2@test.com',
+      'testAlias, testUser2@test.com',
       '--permsetname',
       'DreamHouse',
     ])


### PR DESCRIPTION
### What does this PR do?
properly resolves aliases before querying the org
switch to singleRecordQuery to improve error output for users
rename variables for clarity...the renaming makes this diff hard to grok...the "actual change" is on L63
test a username and an alias in onbehalfof

### What issues does this PR fix or reference?
@W-8886621@