### PR TITLE
fix: releases using 2 vars from Context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,7 @@ workflows:
           filters:
             branches:
               only: main
+          context: CLI_CTC
   test-ts-update:
     triggers:
       - schedule:


### PR DESCRIPTION
### What does this PR do?
attempts CTC release with env vars moved to a context

### What issues does this PR fix or reference?
@W-7869694@