### PR TITLE
fix: add note about using aliases with -u or -o

### DIFF
--- a/messages/permset.assign.json
+++ b/messages/permset.assign.json
@@ -1,5 +1,5 @@
 {
-  "description": "assign a permission set to one or more users of an org",
+  "description": "assign a permission set to one or more users of an org\nTo specify an alias for the -u or -o parameter, use the username alias you set with the \"alias:set\" CLI command, not the User.Alias value of the org user.",
   "examples": [
     "sfdx force:user:permset:assign -n DreamHouse",
     "sfdx force:user:permset:assign -n DreamHouse -u me@my.org",


### PR DESCRIPTION
### What does this PR do?

Adds a bit of help to explain that in this context "aliases" refer to the thing you set with alias:set, not the User.Alias value of the org user. 

### What issues does this PR fix or reference?

@W-8583177@