### PR TITLE
fix examples in the permset|license assign commands

### DIFF
--- a/messages/permset.assign.md
+++ b/messages/permset.assign.md
@@ -4,14 +4,21 @@ Assign a permission set to one or more users of a scratch org.
 
 # description
 
-To specify an alias for the --target-org or --on-behalf-of flags, use the CLI username alias, such as the one you set
-with the "alias set" command. Don't use the value of the Alias field of the User Salesforce object for the org user.
+To specify an alias for the --target-org or --on-behalf-of flags, use the CLI username alias, such as the one you set with the "alias set" command. Don't use the value of the Alias field of the User Salesforce object for the org user.
+
+To assign multiple permission sets, either set multiple --name flags or a single --name flag with multiple names separated by spaces. Enclose names that contain spaces in one set of double quotes. The same syntax applies to --on-behalf-of.
+
+# description.force
+
+To specify an alias for the --target-org or --on-behalf-of flags, use the CLI username alias, such as the one you set with the "alias set" command. Don't use the value of the Alias field of the User Salesforce object for the org user.
+
+To assign multiple permission sets, either set multiple --perm-set-name flags or a single --perm-set-name flag with multiple names separated by spaces. Enclose names that contain spaces in one set of double quotes. The same syntax applies to --on-behalf-of.
 
 # examples
 
 - Assign two permission sets called DreamHouse and LargeDreamHouse to original admin user of your default scratch org:
 
-  <%= config.bin %> <%= command.id %> --name "DreamHouse, LargeDreamHouse"
+  <%= config.bin %> <%= command.id %> --name DreamHouse --name LargeDreamHouse
 
 - Assign the Dreamhouse permission set to the original admin user of the scratch org with alias "my-scratch":
 
@@ -19,15 +26,29 @@ with the "alias set" command. Don't use the value of the Alias field of the User
 
 - Assign the Dreamhouse permission set to the specified list of users of your default scratch org:
 
-  <%= config.bin %> <%= command.id %> --name DreamHouse --on-behalf-of "user1@my.org,user2,user3"
+  <%= config.bin %> <%= command.id %> --name DreamHouse --on-behalf-of user1@my.org --on-behalf-of user2 --on-behalf-of user
+
+# examples.force
+
+- Assign two permission sets called DreamHouse and LargeDreamHouse to original admin user of your default scratch org:
+
+  <%= config.bin %> <%= command.id %> --perm-set-name DreamHouse --perm-set-name LargeDreamHouse
+
+- Assign the Dreamhouse permission set to the original admin user of the scratch org with alias "my-scratch":
+
+  <%= config.bin %> <%= command.id %> --perm-set-name DreamHouse --target-org my-scratch
+
+- Assign the Dreamhouse permission set to the specified list of users of your default scratch org:
+
+  <%= config.bin %> <%= command.id %> --perm-set-name DreamHouse --on-behalf-of user1@my.org --on-behalf-of user2 --on-behalf-of user
 
 # flags.onBehalfOf.summary
 
-Comma-separated list of usernames or aliases to assign the permission set to.
+Username or alias to assign the permission set to.
 
 # flags.permsetName.summary
 
-Comma-separated list of permission sets to assign.
+Permission set to assign.
 
 # flags.target-org.summary
 

--- a/messages/permsetlicense.assign.md
+++ b/messages/permsetlicense.assign.md
@@ -6,6 +6,8 @@ Assign a permission set license to one or more users of a scratch org.
 
 To specify an alias for the --target-org or --on-behalf-of flags, use the CLI username alias, such as the one you set with the "alias set" command. Don't use the value of the Alias field of the User Salesforce object for the org user.
 
+To assign multiple permission sets, either set multiple --name flags or a single --name flag with multiple names separated by spaces. Enclose names that contain spaces in one set of double quotes. The same syntax applies to --on-behalf-of.
+
 # examples
 
 - Assign the DreamHouse permission set license to original admin user of your default scratch org:
@@ -18,11 +20,11 @@ To specify an alias for the --target-org or --on-behalf-of flags, use the CLI us
 
 - Assign the Dreamhouse permission set license to the specified list of users of your default scratch org:
 
-  <%= config.bin %> <%= command.id %> --name DreamHouse --on-behalf-of "user1@my.org,user2,user3"
+  <%= config.bin %> <%= command.id %> --name DreamHouse --on-behalf-of user1@my.org --on-behalf-of user2 --on-behalf-of user3
 
 # flags.onBehalfOf.summary
 
-Comma-separated list of usernames or aliases to assign the permission set license to.
+Usernames or alias to assign the permission set license to.
 
 # flags.name.summary
 

--- a/src/commands/force/user/permset/assign.ts
+++ b/src/commands/force/user/permset/assign.ts
@@ -16,8 +16,8 @@ const messages = Messages.loadMessages('@salesforce/plugin-user', 'permset.assig
 export class ForceUserPermSetAssignCommand extends UserPermSetAssignBaseCommand {
   public static readonly hidden = true;
   public static readonly summary = messages.getMessage('summary');
-  public static readonly description = messages.getMessage('description');
-  public static readonly examples = messages.getMessages('examples');
+  public static readonly description = messages.getMessage('description.force');
+  public static readonly examples = messages.getMessages('examples.force');
   public static readonly flags = {
     'perm-set-name': arrayWithDeprecation({
       aliases: ['permsetname'],


### PR DESCRIPTION
### What does this PR do?

Fixes incorrect examples. 

**NOTE**: the "force user permset assign" command has the --perm-set-name flag, but the "org assign permset" command (NOT an alias of the first one) has the "--name" flag.  Bug?  Or intentional?    I worked around the issue in this PR,  but maybe we should make the flag names the same?  Or is it too late, now that they’re out? Thx!

### What issues does this PR fix or reference?

@W-12769947@
