### PR TITLE
fix: pass bin to message

### DIFF
--- a/messages/password.generate.md
+++ b/messages/password.generate.md
@@ -78,7 +78,7 @@ Successfully set passwords:%s
 
 # viewWithCommand
 
-You can see the password again by running "<%= config.bin %> org display user -o %s".
+You can see the password again by running "%s org display user -o %s".
 
 # flags.target-org.summary
 

--- a/src/baseCommands/user/password/generate.ts
+++ b/src/baseCommands/user/password/generate.ts
@@ -88,7 +88,7 @@ export abstract class UserPasswordGenerateBaseCommand extends SfCommand<Generate
   private print(passwordData: PasswordData[]): void {
     if (passwordData) {
       const successMsg = messages.getMessage('success', [passwordData[0].password, passwordData[0].username]);
-      const viewMsg = messages.getMessage('viewWithCommand', [passwordData[0].username]);
+      const viewMsg = messages.getMessage('viewWithCommand', [this.config.bin, passwordData[0].username]);
       this.log(`${successMsg}${os.EOL}${viewMsg}`);
     } else {
       this.log(messages.getMessage('successMultiple', [os.EOL]));


### PR DESCRIPTION
### What does this PR do?
`config.bin` replacement does not work on standard messages. We now pass it in from the command. 

### What issues does this PR fix or reference?
[skip-validate-pr]

Before and after:
<img width="1358" alt="Screenshot 2023-07-25 at 2 06 40 PM" src="https://github.com/salesforcecli/plugin-user/assets/1715111/dc363877-704c-4330-a328-e9588b6cae5b">
