### PR TITLE
refactor: use authinfo update instead of mutating getFields

### DIFF
--- a/src/baseCommands/user/password/generate.ts
+++ b/src/baseCommands/user/password/generate.ts
@@ -51,7 +51,7 @@ export abstract class UserPasswordGenerateBaseCommand extends SfCommand<Generate
         );
 
         // userId is used by `assignPassword` so we need to set it here
-        authInfo.getFields().userId = result.Id;
+        authInfo.update({ userId: result.Id });
         await user.assignPassword(authInfo, password);
 
         password.value((pass) => {


### PR DESCRIPTION
What does this PR do?
@W-14085765@ will make AuthInfo.getFields readonly. Preemptively prepare for that change so that we don't have to do it later and so that auth's tests can be used to valid the bigger configFile change safety.

What issues does this PR fix or reference?