### PR TITLE
fix: handle missing createdOrgInstance field

### DIFF
--- a/src/commands/org/create/user.ts
+++ b/src/commands/org/create/user.ts
@@ -7,7 +7,6 @@
 import { EOL } from 'node:os';
 import fs from 'node:fs';
 
-
 import {
   AuthInfo,
   Connection,
@@ -34,7 +33,7 @@ import {
 } from '@salesforce/sf-plugins-core';
 import { Interfaces } from '@oclif/core';
 
-Messages.importMessagesDirectoryFromMetaUrl(import.meta.url)
+Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 const messages = Messages.loadMessages('@salesforce/plugin-user', 'create');
 
 type SuccessMsg = {
@@ -320,7 +319,7 @@ const getValidatedConnection = async (targetOrg: Org, apiVersion?: string): Prom
   if (
     conn.getAuthInfo().isJwt() &&
     // hyperforce sandbox instances end in S like USA254S
-    targetOrg.getField<string>(Org.Fields.CREATED_ORG_INSTANCE).endsWith('S')
+    targetOrg.getField<string>(Org.Fields.CREATED_ORG_INSTANCE)?.endsWith('S')
   ) {
     throw messages.createError('error.jwtHyperforce');
   }


### PR DESCRIPTION
### What does this PR do?
Prevent `TypeError` when checking the AuthFields for `createdOrgInstance`.  In very rare cases, the `SignupInstance` field is not set properly during the signup and isn't on `ScratchOrgInfo`.

### What issues does this PR fix or reference?
@W-14801997@

QA:
Remove the `createdOrgInstance` field from a scratch org auth file, then run `sf org create user` targeting that scratch org.  Without the fix you'll get a TypeError.  With the fix you won't.  If the scratch org is on a hyperforce instance the user create command will still fail.  If it's not on hyperforce it will work.