### PR TITLE
chore!: remove deprecated hub flag

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -1,100 +1,74 @@
 [
   {
+    "alias": [],
     "command": "force:user:password:generate",
-    "plugin": "@salesforce/plugin-user",
-    "flags": [
-      "api-version",
-      "complexity",
-      "json",
-      "length",
-      "loglevel",
-      "on-behalf-of",
-      "target-dev-hub",
-      "target-org"
-    ],
-    "alias": [],
-    "flagChars": ["c", "l", "o", "u", "v"],
-    "flagAliases": ["apiversion", "onbehalfof", "targetdevhubusername", "targetusername"]
+    "flagAliases": ["apiversion", "onbehalfof", "targetusername"],
+    "flagChars": ["c", "l", "o", "u"],
+    "flags": ["api-version", "complexity", "json", "length", "loglevel", "on-behalf-of", "target-org"],
+    "plugin": "@salesforce/plugin-user"
   },
   {
+    "alias": [],
     "command": "force:user:permset:assign",
-    "plugin": "@salesforce/plugin-user",
-    "flags": ["api-version", "json", "loglevel", "on-behalf-of", "perm-set-name", "target-org"],
-    "alias": [],
+    "flagAliases": ["apiversion", "onbehalfof", "permsetname", "targetusername"],
     "flagChars": ["n", "o", "u"],
-    "flagAliases": ["apiversion", "onbehalfof", "permsetname", "targetusername"]
+    "flags": ["api-version", "json", "loglevel", "on-behalf-of", "perm-set-name", "target-org"],
+    "plugin": "@salesforce/plugin-user"
   },
   {
+    "alias": [],
     "command": "force:user:permsetlicense:assign",
-    "plugin": "@salesforce/plugin-user",
-    "flags": ["api-version", "json", "loglevel", "name", "on-behalf-of", "target-org"],
-    "alias": [],
+    "flagAliases": ["apiversion", "onbehalfof", "perm-set-license", "psl", "targetusername"],
     "flagChars": ["b", "n", "u"],
-    "flagAliases": ["apiversion", "onbehalfof", "perm-set-license", "psl", "targetusername"]
+    "flags": ["api-version", "json", "loglevel", "name", "on-behalf-of", "target-org"],
+    "plugin": "@salesforce/plugin-user"
   },
   {
+    "alias": [],
     "command": "org:assign:permset",
-    "plugin": "@salesforce/plugin-user",
-    "flags": ["api-version", "json", "name", "on-behalf-of", "target-org"],
-    "alias": [],
+    "flagAliases": ["onbehalfof", "permsetname"],
     "flagChars": ["b", "n", "o"],
-    "flagAliases": ["onbehalfof", "permsetname"]
+    "flags": ["api-version", "json", "name", "on-behalf-of", "target-org"],
+    "plugin": "@salesforce/plugin-user"
   },
   {
+    "alias": [],
     "command": "org:assign:permsetlicense",
-    "plugin": "@salesforce/plugin-user",
-    "flags": ["api-version", "json", "name", "on-behalf-of", "target-org"],
-    "alias": [],
+    "flagAliases": ["onbehalfof", "perm-set-license", "psl"],
     "flagChars": ["b", "n", "o"],
-    "flagAliases": ["onbehalfof", "perm-set-license", "psl"]
+    "flags": ["api-version", "json", "name", "on-behalf-of", "target-org"],
+    "plugin": "@salesforce/plugin-user"
   },
   {
-    "command": "org:create:user",
-    "plugin": "@salesforce/plugin-user",
-    "flags": [
-      "api-version",
-      "definition-file",
-      "json",
-      "loglevel",
-      "set-alias",
-      "set-unique-username",
-      "target-dev-hub",
-      "target-org"
-    ],
     "alias": ["force:user:create"],
-    "flagChars": ["a", "f", "o", "s", "v"],
-    "flagAliases": [
-      "apiversion",
-      "definitionfile",
-      "setalias",
-      "setuniqueusername",
-      "targetdevhubusername",
-      "targetusername",
-      "u"
-    ]
+    "command": "org:create:user",
+    "flagAliases": ["apiversion", "definitionfile", "setalias", "setuniqueusername", "targetusername", "u"],
+    "flagChars": ["a", "f", "o", "s"],
+    "flags": ["api-version", "definition-file", "json", "loglevel", "set-alias", "set-unique-username", "target-org"],
+    "plugin": "@salesforce/plugin-user"
   },
   {
-    "command": "org:display:user",
-    "plugin": "@salesforce/plugin-user",
-    "flags": ["api-version", "json", "loglevel", "target-dev-hub", "target-org"],
     "alias": ["force:user:display"],
-    "flagChars": ["o", "v"],
-    "flagAliases": ["apiversion", "targetdevhubusername", "targetusername", "u"]
+    "command": "org:display:user",
+    "flagAliases": ["apiversion", "targetusername", "u"],
+    "flagChars": ["o"],
+    "flags": ["api-version", "json", "loglevel", "target-org"],
+    "plugin": "@salesforce/plugin-user"
   },
   {
-    "command": "org:generate:password",
-    "plugin": "@salesforce/plugin-user",
-    "flags": ["api-version", "complexity", "json", "length", "on-behalf-of", "target-org"],
     "alias": [],
+    "command": "org:generate:password",
+    "flagAliases": ["onbehalfof"],
     "flagChars": ["b", "c", "l", "o"],
-    "flagAliases": ["onbehalfof"]
+    "flags": ["api-version", "complexity", "json", "length", "on-behalf-of", "target-org"],
+    "plugin": "@salesforce/plugin-user"
   },
   {
-    "command": "org:list:users",
-    "plugin": "@salesforce/plugin-user",
-    "flags": ["api-version", "json", "loglevel", "target-dev-hub", "target-org"],
     "alias": ["force:user:list"],
-    "flagChars": ["o", "v"],
-    "flagAliases": ["apiversion", "targetusername", "u"]
+    "command": "org:list:users",
+    "flagAliases": ["apiversion", "targetusername", "u"],
+    "flagChars": ["o"],
+    "flags": ["api-version", "json", "loglevel", "target-org"],
+    "plugin": "@salesforce/plugin-user"
   }
 ]

--- a/messages/create.md
+++ b/messages/create.md
@@ -74,10 +74,6 @@ The username "%s" already exists in this or another Salesforce org. Usernames mu
 Successfully created user "%s" with ID %s for org %s.%s
 See more details about this user by running "%s org user display -o %s".
 
-# flags.target-hub.deprecation
-
-The --target-dev-hub flag is deprecated and is no longer used by this command. The flag will be removed in API version 57.0 or later.
-
 # error.nonScratchOrg
 
 This command works with only scratch orgs.

--- a/messages/display.md
+++ b/messages/display.md
@@ -23,8 +23,3 @@ Sharing this information is equivalent to logging someone in under the current c
 access and escalation of privilege.
 For additional information, review the authorization section of
 the https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_auth_web_flow.htm
-
-# flags.target-hub.deprecation
-
-The --target-dev-hub flag is deprecated and is no longer used by this command. The flag will be removed in API version
-57.0 or later.

--- a/messages/list.md
+++ b/messages/list.md
@@ -15,11 +15,3 @@ For scratch orgs, the list includes any users you've created with the "org creat
 - List the locally-authenticated users of the specified org:
 
   <%= config.bin %> <%= command.id %> --target-org me@my.org
-
-# flags.target-dev-hub.summary
-
-Username or alias of the Dev Hub org.
-
-# flags.target-dev-hub.deprecation
-
-The --target-dev-hub flag is deprecated and is no longer used by this command. The flag will be removed in API version 57.0 or later.

--- a/messages/password.generate.md
+++ b/messages/password.generate.md
@@ -90,7 +90,3 @@ Scratch org alias or login user.
 
 Found a comma-separated list of usernames or aliases for the --on-behalf-of flag. Either specify one per flag or
 separate by a space.
-
-# flags.target-hub.deprecation
-
-The --target-dev-hub flag is deprecated and is no longer used by this command. The flag will be removed in API version 57.0 or later.

--- a/src/baseCommands/user/password/generate.ts
+++ b/src/baseCommands/user/password/generate.ts
@@ -6,11 +6,10 @@
  */
 import { EOL } from 'node:os';
 
-
 import { SfCommand } from '@salesforce/sf-plugins-core';
 import { AuthInfo, Connection, Messages, Org, SfError, StateAggregator, User } from '@salesforce/core';
 
-Messages.importMessagesDirectoryFromMetaUrl(import.meta.url)
+Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 const messages = Messages.loadMessages('@salesforce/plugin-user', 'password.generate');
 
 export type PasswordData = {

--- a/src/baseCommands/user/permset/assign.ts
+++ b/src/baseCommands/user/permset/assign.ts
@@ -5,12 +5,10 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-
-
 import { Connection, Messages, Org, SfError, StateAggregator, User } from '@salesforce/core';
 import { SfCommand } from '@salesforce/sf-plugins-core';
 
-Messages.importMessagesDirectoryFromMetaUrl(import.meta.url)
+Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 
 type SuccessMsg = {
   name: string;

--- a/src/baseCommands/user/permsetlicense/assign.ts
+++ b/src/baseCommands/user/permsetlicense/assign.ts
@@ -5,12 +5,10 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-
-
 import { Connection, Logger, Messages, SfError, StateAggregator } from '@salesforce/core';
 import { SfCommand } from '@salesforce/sf-plugins-core';
 
-Messages.importMessagesDirectoryFromMetaUrl(import.meta.url)
+Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 const messages = Messages.loadMessages('@salesforce/plugin-user', 'permsetlicense.assign');
 
 type SuccessMsg = {

--- a/src/commands/force/user/password/generate.ts
+++ b/src/commands/force/user/password/generate.ts
@@ -5,13 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import {
-  arrayWithDeprecation,
-  Flags,
-  loglevel,
-  optionalHubFlagWithDeprecations,
-  orgApiVersionFlagWithDeprecations,
-} from '@salesforce/sf-plugins-core';
+import { arrayWithDeprecation, Flags, loglevel, orgApiVersionFlagWithDeprecations } from '@salesforce/sf-plugins-core';
 import { Messages } from '@salesforce/core';
 import { ensureArray } from '@salesforce/kit';
 import { GenerateResult, UserPasswordGenerateBaseCommand } from '../../../../baseCommands/user/password/generate.js';
@@ -50,13 +44,6 @@ export class ForceUserPasswordGenerateCommand extends UserPasswordGenerateBaseCo
       max: 5,
       default: 5,
     }),
-    'target-dev-hub': {
-      ...optionalHubFlagWithDeprecations,
-      hidden: true,
-      deprecated: {
-        message: messages.getMessage('flags.target-hub.deprecation'),
-      },
-    },
     'target-org': Flags.requiredOrg({
       char: 'u',
       summary: messages.getMessage('flags.target-org.summary'),

--- a/src/commands/org/assign/permset.ts
+++ b/src/commands/org/assign/permset.ts
@@ -5,14 +5,12 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-
-
 import { Messages, Org } from '@salesforce/core';
 import { Flags } from '@salesforce/sf-plugins-core';
 import { ensureArray } from '@salesforce/kit';
 import { PermsetAssignResult, UserPermSetAssignBaseCommand } from '../../../baseCommands/user/permset/assign.js';
 
-Messages.importMessagesDirectoryFromMetaUrl(import.meta.url)
+Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 const messages = Messages.loadMessages('@salesforce/plugin-user', 'permset.assign');
 
 export class AssignPermSetCommand extends UserPermSetAssignBaseCommand {

--- a/src/commands/org/assign/permsetlicense.ts
+++ b/src/commands/org/assign/permsetlicense.ts
@@ -5,14 +5,12 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-
-
 import { Messages } from '@salesforce/core';
 import { arrayWithDeprecation, Flags } from '@salesforce/sf-plugins-core';
 import { ensureArray } from '@salesforce/kit';
 import { PSLResult, UserPermSetLicenseAssignBaseCommand } from '../../../baseCommands/user/permsetlicense/assign.js';
 
-Messages.importMessagesDirectoryFromMetaUrl(import.meta.url)
+Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 const messages = Messages.loadMessages('@salesforce/plugin-user', 'permsetlicense.assign');
 
 export class AssignPermSetLicenseCommand extends UserPermSetLicenseAssignBaseCommand {

--- a/src/commands/org/create/user.ts
+++ b/src/commands/org/create/user.ts
@@ -27,7 +27,6 @@ import {
   loglevel,
   orgApiVersionFlagWithDeprecations,
   parseVarArgs,
-  optionalHubFlagWithDeprecations,
   requiredOrgFlagWithDeprecations,
   SfCommand,
 } from '@salesforce/sf-plugins-core';
@@ -74,13 +73,6 @@ export class CreateUserCommand extends SfCommand<CreateUserOutput> {
       aliases: ['setuniqueusername'],
       deprecateAliases: true,
     }),
-    'target-dev-hub': {
-      ...optionalHubFlagWithDeprecations,
-      hidden: true,
-      deprecated: {
-        message: messages.getMessage('flags.target-hub.deprecation'),
-      },
-    },
     'target-org': requiredOrgFlagWithDeprecations,
     'api-version': orgApiVersionFlagWithDeprecations,
     loglevel,

--- a/src/commands/org/display/user.ts
+++ b/src/commands/org/display/user.ts
@@ -5,19 +5,16 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-
-
 import { AuthFields, Connection, Logger, Messages, StateAggregator } from '@salesforce/core';
 import { ensureString } from '@salesforce/ts-types';
 import {
   loglevel,
-  optionalHubFlagWithDeprecations,
   orgApiVersionFlagWithDeprecations,
   requiredOrgFlagWithDeprecations,
   SfCommand,
 } from '@salesforce/sf-plugins-core';
 
-Messages.importMessagesDirectoryFromMetaUrl(import.meta.url)
+Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 const messages = Messages.loadMessages('@salesforce/plugin-user', 'display');
 
 export type DisplayUserResult = {
@@ -39,13 +36,6 @@ export class DisplayUserCommand extends SfCommand<DisplayUserResult> {
   public static readonly description = messages.getMessage('description');
   public static readonly examples = messages.getMessages('examples');
   public static readonly flags = {
-    'target-dev-hub': {
-      ...optionalHubFlagWithDeprecations,
-      hidden: true,
-      deprecated: {
-        message: messages.getMessage('flags.target-hub.deprecation'),
-      },
-    },
     'target-org': requiredOrgFlagWithDeprecations,
     'api-version': orgApiVersionFlagWithDeprecations,
     loglevel,

--- a/src/commands/org/generate/password.ts
+++ b/src/commands/org/generate/password.ts
@@ -5,13 +5,12 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-
 import { Flags } from '@salesforce/sf-plugins-core';
 import { Messages } from '@salesforce/core';
 import { ensureArray } from '@salesforce/kit';
 import { GenerateResult, UserPasswordGenerateBaseCommand } from '../../../baseCommands/user/password/generate.js';
 
-Messages.importMessagesDirectoryFromMetaUrl(import.meta.url)
+Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 const messages = Messages.loadMessages('@salesforce/plugin-user', 'password.generate');
 
 export type PasswordData = {

--- a/src/commands/org/list/users.ts
+++ b/src/commands/org/list/users.ts
@@ -7,7 +7,6 @@
 
 import { Connection, Messages, StateAggregator } from '@salesforce/core';
 import {
-  Flags,
   loglevel,
   orgApiVersionFlagWithDeprecations,
   requiredOrgFlagWithDeprecations,
@@ -43,14 +42,6 @@ export class ListUsersCommand extends SfCommand<ListUsers> {
   public static readonly description = messages.getMessage('description');
   public static readonly examples = messages.getMessages('examples');
   public static readonly flags = {
-    'target-dev-hub': Flags.optionalOrg({
-      char: 'v',
-      summary: messages.getMessage('flags.target-dev-hub.summary'),
-      hidden: true,
-      deprecated: {
-        message: messages.getMessage('flags.target-dev-hub.deprecation'),
-      },
-    }),
     'target-org': requiredOrgFlagWithDeprecations,
     'api-version': orgApiVersionFlagWithDeprecations,
     loglevel,

--- a/test/commands/display.test.ts
+++ b/test/commands/display.test.ts
@@ -17,10 +17,6 @@ describe('org:display:user', () => {
   const $$ = new TestContext();
 
   const testOrg = new MockTestOrgData();
-  const devHub = new MockTestOrgData();
-  devHub.username = 'mydevhub.org';
-  devHub.devHubUsername = 'mydevhub.org';
-  devHub.isDevHub = true;
   const defaultOrg = new MockTestOrgData();
   defaultOrg.orgId = 'abc123';
   defaultOrg.username = 'defaultusername@test.com';
@@ -30,8 +26,8 @@ describe('org:display:user', () => {
   defaultOrg.password = '-a098u234/1!@#';
 
   async function prepareStubs(queries = false) {
-    await $$.stubAuths(testOrg, devHub, defaultOrg);
-    await $$.stubConfig({ 'target-dev-hub': devHub.username, 'target-org': defaultOrg.username });
+    await $$.stubAuths(testOrg, defaultOrg);
+    await $$.stubConfig({ 'target-org': defaultOrg.username });
     $$.stubAliases({ testAlias: 'defaultusername@test.com' });
 
     if (queries) {
@@ -85,10 +81,7 @@ describe('org:display:user', () => {
       profileName: 'profileName',
       username: 'defaultusername@test.com',
     };
-    const displayCommand = new DisplayUserCommand(
-      ['--json', '--target-org', defaultOrg.username, '--target-dev-hub', devHub.username],
-      {} as Config
-    );
+    const displayCommand = new DisplayUserCommand(['--json', '--target-org', defaultOrg.username], {} as Config);
     const result = await displayCommand.run();
     expect(result).to.deep.equal(expected);
   });
@@ -107,7 +100,7 @@ describe('org:display:user', () => {
       username: defaultOrg.username,
     };
     const displayCommand = new DisplayUserCommand(
-      ['--json', '--targetusername', 'defaultusername@test.com', '--targetdevhubusername', devHub.username],
+      ['--json', '--targetusername', 'defaultusername@test.com'],
       {} as Config
     );
     const result = await displayCommand.run();

--- a/test/commands/list.test.ts
+++ b/test/commands/list.test.ts
@@ -59,14 +59,9 @@ describe('org:list:users', () => {
   user2Org.loginUrl = 'login.test.com';
   user2Org.userId = '0052D0000043PcBQAU';
 
-  const devHub = new MockTestOrgData();
-  devHub.username = 'mydevhub.org';
-  devHub.devHubUsername = 'mydevhub.org';
-  devHub.isDevHub = true;
-
   beforeEach(async () => {
-    await $$.stubAuths(user1Org, devHub);
-    await $$.stubConfig({ 'target-dev-hub': devHub.username, 'target-org': user1Org.username });
+    await $$.stubAuths(user1Org);
+    await $$.stubConfig({ 'target-org': user1Org.username });
     $$.stubAliases({ testAlias: user1 });
 
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -136,19 +131,13 @@ describe('org:list:users', () => {
   });
 
   it('should display the correct information invoked with an alias', async () => {
-    const listComm = new ListUsersCommand(
-      ['--json', '--target-org', 'testAlias', '--target-dev-hub', devHub.username],
-      {} as Config
-    );
+    const listComm = new ListUsersCommand(['--json', '--target-org', 'testAlias'], {} as Config);
     const result = await listComm.run();
     expect(result).to.deep.equal(expected);
   });
 
   it('should display the correct information invoked by name', async () => {
-    const listComm = new ListUsersCommand(
-      ['--json', '--target-org', user1, '--target-dev-hub', devHub.username],
-      {} as Config
-    );
+    const listComm = new ListUsersCommand(['--json', '--target-org', user1], {} as Config);
     const result = await listComm.run();
     expect(result).to.deep.equal(expected);
   });

--- a/test/commands/password/generate.test.ts
+++ b/test/commands/password/generate.test.ts
@@ -5,8 +5,6 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-
-
 import { Connection, Messages, User } from '@salesforce/core';
 import { MockTestOrgData, TestContext } from '@salesforce/core/lib/testSetup.js';
 import { SecureBuffer } from '@salesforce/core/lib/crypto/secureBuffer.js';
@@ -14,7 +12,7 @@ import { assert, expect } from 'chai';
 import { Config } from '@oclif/core';
 import { PasswordData, GenerateUserPasswordCommand } from '../../../src/commands/org/generate/password.js';
 
-Messages.importMessagesDirectoryFromMetaUrl(import.meta.url)
+Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 const messages = Messages.loadMessages('@salesforce/plugin-user', 'password.generate');
 
 describe('org:generate:password', () => {
@@ -31,15 +29,11 @@ describe('org:generate:password', () => {
   }
 
   const testOrg = new MockTestOrgData();
-  const devHub = new MockTestOrgData();
-  devHub.username = 'mydevhub.org';
-  devHub.devHubUsername = 'mydevhub.org';
-  devHub.isDevHub = true;
   let queryStub: sinon.SinonStub;
 
   async function prepareStubs(throws = false, generatePassword = true) {
-    await $$.stubAuths(testOrg, devHub);
-    await $$.stubConfig({ 'target-dev-hub': devHub.username, 'target-org': testOrg.username });
+    await $$.stubAuths(testOrg);
+    await $$.stubConfig({ 'target-org': testOrg.username });
     queryStub = $$.SANDBOXES.CONNECTION.stub(Connection.prototype, 'singleRecordQuery').resolves({
       Id: '0052D0000043PawWWR',
     });

--- a/test/commands/permset/assign.test.ts
+++ b/test/commands/permset/assign.test.ts
@@ -27,14 +27,10 @@ describe('org:assign:permset', () => {
 
   const testOrg = new MockTestOrgData();
   testOrg.username = 'defaultusername@test.com';
-  const devHub = new MockTestOrgData();
-  devHub.username = 'mydevhub.org';
-  devHub.devHubUsername = 'mydevhub.org';
-  devHub.isDevHub = true;
 
   async function prepareStubs(throws = false) {
-    await $$.stubAuths(testOrg, devHub);
-    await $$.stubConfig({ 'target-dev-hub': devHub.username, 'target-org': testOrg.username });
+    await $$.stubAuths(testOrg);
+    await $$.stubConfig({ 'target-org': testOrg.username });
 
     $$.SANDBOXES.CONNECTION.stub(Connection.prototype, 'query').resolves({
       records: [{ Id: '1234567890' }],

--- a/test/commands/permsetlicense/assign.test.ts
+++ b/test/commands/permsetlicense/assign.test.ts
@@ -26,11 +26,6 @@ describe('org:assign:permsetlicense', () => {
 
   const testOrg = new MockTestOrgData();
   testOrg.username = 'defaultusername@test.com';
-  const devHub = new MockTestOrgData();
-  devHub.username = 'mydevhub.org';
-  devHub.devHubUsername = 'mydevhub.org';
-  devHub.isDevHub = true;
-
   const goodPSL = 'existingPSL';
   const badPSL = 'nonExistingPSL';
 
@@ -38,8 +33,8 @@ describe('org:assign:permsetlicense', () => {
   const username2 = 'testUser2@test.com';
 
   async function prepareStubs() {
-    await $$.stubAuths(testOrg, devHub);
-    await $$.stubConfig({ 'target-dev-hub': devHub.username, 'target-org': testOrg.username });
+    await $$.stubAuths(testOrg);
+    await $$.stubConfig({ 'target-org': testOrg.username });
 
     $$.stubAliases({ testAlias: username1 });
 


### PR DESCRIPTION
### What does this PR do?

Removes deprecated `target-dev-hub` flag from commands. This flag isn't required for commands to work, we deprecated it hide it a few months ago: https://github.com/salesforcecli/plugin-user/pull/332

### What issues does this PR fix or reference?
@W-14989955@