### PR TITLE
fix: remove duplicate profile name info sent to stdout

### DIFF
--- a/src/commands/org/display/user.ts
+++ b/src/commands/org/display/user.ts
@@ -120,7 +120,6 @@ export class DisplayUserCommand extends SfCommand<DisplayUserResult> {
       [
         { key: 'Username', label: result.username ?? 'unknown' },
         { key: 'Profile Name', label: result.profileName },
-        { key: 'Profile Name', label: result.profileName },
         { key: 'Id', label: result.id },
         { key: 'Org Id', label: result.orgId },
         ...(result.accessToken ? [{ key: 'Access Token', label: result.accessToken }] : []),


### PR DESCRIPTION
### What does this PR do?
Removes duplicate "Profile Name" when running command `sf org display user -o <target-org>`.
### What issues does this PR fix or reference?
https://github.com/forcedotcom/cli/issues/2762

[skip-validate-pr]