### PR TITLE
fix: remove deprecated sfdx-core aliasAccessor method

### DIFF
--- a/src/commands/org/create/user.ts
+++ b/src/commands/org/create/user.ts
@@ -151,8 +151,7 @@ export class CreateUserCommand extends SfCommand<CreateUserOutput> {
     // Set the alias if specified
     if (flags['set-alias']) {
       const stateAggregator = await StateAggregator.getInstance();
-      stateAggregator.aliases.set(flags['set-alias'], fields.username);
-      await stateAggregator.aliases.write();
+      await stateAggregator.aliases.setAndSave(flags['set-alias'], fields.username);
     }
 
     fields.id = ensureString(newUserAuthInfo.getFields().userId);


### PR DESCRIPTION
> can merge without any sfdx-core changes.

### What does this PR do?
aliasAccessor.write and .set are going away in corev7 (set was already doing a save/write).  

### What issues does this PR fix or reference?
@W-15387805@

https://github.com/forcedotcom/sfdx-core/actions/runs/8525711685/job/23353427724?pr=1045