### PR TITLE
fix: forcing NUTs to use sfdx-auth-url (W-23517580)

### DIFF
--- a/test/allCommands.nut.ts
+++ b/test/allCommands.nut.ts
@@ -41,7 +41,7 @@ describe('verifies all commands run successfully ', () => {
       project: {
         sourceDir: join('test', 'df17AppBuilding'),
       },
-      devhubAuthStrategy: 'AUTO',
+      devhubAuthStrategy: 'AUTH_URL',
       scratchOrgs: [
         {
           setDefault: true,

--- a/test/allCommandsNoJSON.nut.ts
+++ b/test/allCommandsNoJSON.nut.ts
@@ -27,7 +27,7 @@ describe('verifies all commands run successfully (no json)', () => {
         // destinationDir: projectPath,
         sourceDir: join('test', 'df17AppBuilding'),
       },
-      devhubAuthStrategy: 'AUTO',
+      devhubAuthStrategy: 'AUTH_URL',
       scratchOrgs: [
         {
           setDefault: true,

--- a/test/commands/permsetlicense/assign.nut.ts
+++ b/test/commands/permsetlicense/assign.nut.ts
@@ -28,7 +28,7 @@ describe('PermissionSetLicense tests', () => {
       project: {
         sourceDir: join('test', 'df17AppBuilding'),
       },
-      devhubAuthStrategy: 'AUTO',
+      devhubAuthStrategy: 'AUTH_URL',
       scratchOrgs: [
         {
           setDefault: true,

--- a/test/forceCommands.nut.ts
+++ b/test/forceCommands.nut.ts
@@ -41,7 +41,7 @@ describe('verifies legacy force commands run successfully ', () => {
       project: {
         sourceDir: join('test', 'df17AppBuilding'),
       },
-      devhubAuthStrategy: 'AUTO',
+      devhubAuthStrategy: 'AUTH_URL',
       scratchOrgs: [
         {
           setDefault: true,


### PR DESCRIPTION
### What does this PR do?
Switches NUTs to use `AUTH_URL` instead of `AUTO` for their connection, thus allowing us to fix the OCLIF Core XNUTs based on this repo, which are currently broken because `AUTO` prefers the no-longer-supported-in-Hyperforce JWT based on the repo's secrets.

### What issues does this PR fix or reference?
@W-23517580@